### PR TITLE
Update valid placement method and test for overlap

### DIFF
--- a/lib/board.rb
+++ b/lib/board.rb
@@ -82,9 +82,17 @@ class Board
     ship.length == placement_coordinates.length
   end
 
+  def all_cells_available?(placement_coordinates) 
+    # iterate through placement coordinates and check that the cells are empty?
+
+    placement_coordinates.all? do |coordinate|
+      cells[coordinate].empty?
+    end
+  end
+
   # consider renaming
   def is_good_placement?(ship, placement_coordinates)
-    all_coordinates_valid?(placement_coordinates) && correct_placement_length?(ship, placement_coordinates)
+    all_coordinates_valid?(placement_coordinates) && correct_placement_length?(ship, placement_coordinates) && all_cells_available?(placement_coordinates)
   end
 
   def valid_placement?(ship, cells)

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -135,6 +135,19 @@ describe Board do
       expect(board.valid_placement?(submarine, ["C2", "D3"])).to be false
       expect(board.valid_placement?(cruiser, ["A1", "B2", "C3"])).to be false
     end
+
+    it 'returns false if placement overlaps other ship' do
+      board = Board.new
+      submarine = Ship.new("Submarine", 2)
+      cruiser = Ship.new("Cruiser", 3)
+      cell_1 = board.cells["A1"] 
+      cell_2 = board.cells["A2"] 
+      cell_3 = board.cells["A3"] 
+      expect(board.valid_placement?(submarine, ["A1", "B1"])).to be true
+      
+      board.place(cruiser, ["A1", "A2", "A3"])
+      expect(board.valid_placement?(submarine, ["A1", "B1"])).to be false
+    end
   end
 
   describe '#place' do

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -148,6 +148,18 @@ describe Board do
       board.place(cruiser, ["A1", "A2", "A3"])
       expect(board.valid_placement?(submarine, ["A1", "B1"])).to be false
     end
+
+    it 'returns true if valid placement has no overlap' do
+      board = Board.new
+      submarine = Ship.new("Submarine", 2)
+      cruiser = Ship.new("Cruiser", 3)
+      cell_1 = board.cells["A1"] 
+      cell_2 = board.cells["A2"] 
+      cell_3 = board.cells["A3"] 
+      
+      board.place(cruiser, ["A1", "A2", "A3"])
+      expect(board.valid_placement?(submarine, ["B1", "C1"])).to be true
+    end
   end
 
   describe '#place' do


### PR DESCRIPTION
## What does this change?

valid_placement method

## What does this fix?

Add additional test to check that ships placed on the board cannot overlap. 

## Is this a bug or a feature? 

feature update

## How was this tested?

Tests written to check that two ships can exist on the board as long as they don't overlap and tests written to check that placement is invalid if ships coordinates overlap with another. 